### PR TITLE
Prevent duplicate returned trips and replace undefined `error.setStat…

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -55,7 +55,6 @@ function downloadAllTrips(req, cb) {
     });
   }, function(err, results) {
     if (err) return cb(err);
-//    trips = trips.concat(results); // This line duplicates the results of the last page returned
     filterAndSendTrips(trips, tripIds, cb);
   });
 };

--- a/routes/api.js
+++ b/routes/api.js
@@ -55,7 +55,7 @@ function downloadAllTrips(req, cb) {
     });
   }, function(err, results) {
     if (err) return cb(err);
-    trips = trips.concat(results);
+//    trips = trips.concat(results); // This line duplicates the results of the last page returned
     filterAndSendTrips(trips, tripIds, cb);
   });
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -23,7 +23,8 @@ exports.ensureAuthenticated = (req, res, next) => {
 
   if (req.xhr) {
     const error = new Error('Not logged in');
-    error.setStatus(401);
+//    error.setStatus(401); // There is no setStatus method in Error
+    res.status(401);
     return next(error);
   }
   return res.redirect('/login');

--- a/routes/index.js
+++ b/routes/index.js
@@ -23,7 +23,6 @@ exports.ensureAuthenticated = (req, res, next) => {
 
   if (req.xhr) {
     const error = new Error('Not logged in');
-//    error.setStatus(401); // There is no setStatus method in Error
     res.status(401);
     return next(error);
   }


### PR DESCRIPTION
…us()` with `res.status()`

Function `downloadAllTrips()` duplicates all of the trips that are returned from Automatic in the last page of a paginated response.  This pull request removes the `trips.concat()` statement that duplicates the trips.

I have tested this with my Automatic account which has 417 trips as of today.  The summary display of this app was showing over 540 trips without this fix.  With this fix the summary display shows the correct number of trips.