### PR TITLE
Correct browser Javascript tripId undefined error in Single Trip display

### DIFF
--- a/views/trip.pug
+++ b/views/trip.pug
@@ -14,7 +14,7 @@ block scripts
   script(src="/bower_components/mapbox.js/mapbox.js")
   
   script(type='text/javascript').
-    var trip_id = "!{trip_id}";
+    var tripId = "!{trip_id}";
 
   script(type='text/template' id='singleTrip')
     h2 {{title}}


### PR DESCRIPTION
Rendered Javascript for single trip display is creating the incorrect variable to contain the trip ID. trip.pug needs to use tripId for the Javascript variable name. All of the other Javascript files use that name.

Sorry for the duplicate pull request.  I'm learning git and didn't realize that any changes I make to one of my branches affects all pull requests based on that branch.