### PR TITLE
Filter out 'undefined' items in trips list before sorting

### DIFF
--- a/libs/helpers.js
+++ b/libs/helpers.js
@@ -30,8 +30,12 @@ exports.filterTrips = (trips, tripIds) => {
 
 
 exports.sortByDate = (trips) => {
-  return _.sortBy(trips, (trip) => {
-    return -moment(trip.started_at).valueOf();
+  // Filter out any 'undefined' elements and then sort by trip start time
+  return _.sortBy(_.filter(trips, (trip) => {
+    if(typeof trip != 'undefined') console.log('undefinded trip encountered'); 
+    return typeof trip != 'undefined' 
+    }), (trip) => {
+      return -moment(trip.started_at).valueOf();
   });
 };
 


### PR DESCRIPTION
This patch corrected issue #6 for me.

I don't understand how the undefined members get into the trips array, but this change filters them out. See my log below. Again, this doesn't always happen.

```
GET /bower_components/mapbox.js/images/icons-000000@2x.png 304 20.594 ms - -
GET /images/marker-shadow.png 304 23.207 ms - -
GET /images/marker-a.png 304 32.559 ms - -
GET /images/marker-b.png 304 29.980 ms - -
undefinded trip encountered
.
. (Duplicate lines removed)
.
undefinded trip encountered
GET /api/trips/ 200 8096.625 ms - 1803469

```
